### PR TITLE
Refactor autoselection of layers

### DIFF
--- a/app/assets/scripts/components/country-pilots/single/index.js
+++ b/app/assets/scripts/components/country-pilots/single/index.js
@@ -111,7 +111,7 @@ class CountryPilotSingle extends React.Component {
     // They get temporarily stored in another property and once the map loads
     // the layers are enabled and stored in the correct property.
     const { activeLayers, ...urlState } = this.qsState.getState(
-      props.location.search.substr(1)
+      this.props.location.search.substr(1)
     );
 
     this.state = {
@@ -131,9 +131,14 @@ class CountryPilotSingle extends React.Component {
     const { countryPilotId } = this.props.match.params;
     if (countryPilotId !== prevProps.match.params.countryPilotId) {
       this.requestCountryPilot();
+      this.selectDefaultLayers(countryPilotId, getCommonQsState(this.props));
+      const { activeLayers } = this.qsState.getState(
+        this.props.location.search.substr(1)
+      )
       // Reset state on page change.
       this.setState({
         ...getInitialMapExploreState(),
+        _urlActiveLayers: activeLayers,
         panelPrime: false,
         panelSec: false
       });

--- a/app/assets/scripts/components/products/single/index.js
+++ b/app/assets/scripts/components/products/single/index.js
@@ -111,7 +111,7 @@ class ProductSingle extends React.Component {
     // They get temporarily stored in another property and once the map loads
     // the layers are enabled and stored in the correct property.
     const { activeLayers, ...urlState } = this.qsState.getState(
-      props.location.search.substr(1)
+      this.props.location.search.substr(1)
     );
 
     this.state = {
@@ -131,10 +131,14 @@ class ProductSingle extends React.Component {
     const { productId } = this.props.match.params;
     if (productId !== prevProps.match.params.productId) {
       this.requestProduct();
-      // Reset state on page change.
       this.selectDefaultLayers(productId, getCommonQsState(this.props));
+      const { activeLayers } = this.qsState.getState(
+        this.props.location.search.substr(1)
+      )
+      // Reset state on page change.
       this.setState({
         ...getInitialMapExploreState(),
+        _urlActiveLayers: activeLayers,
         panelPrime: false,
         panelSec: false
       });


### PR DESCRIPTION
Issue: #2

Previously, if a user was currently viewing a Product and selected another from the left sidebar or top dropdown, the product would be selected, but the default layer would not be toggled on. This PR fixes that behavior, so the default layer is selected regardless. This also applies to Country Pilot.