### PR TITLE
remove injected All product, rename/remove Areas text

### DIFF
--- a/app/assets/scripts/components/common/country-pilots-navigation.js
+++ b/app/assets/scripts/components/common/country-pilots-navigation.js
@@ -103,7 +103,7 @@ class CountryPilotsNavigation extends React.Component {
     return (
       <PanelBlockNav>
         <PanelBlockHeader>
-          <PanelBlockTitle>Areas</PanelBlockTitle>
+          <PanelBlockTitle>Country Pilots</PanelBlockTitle>
         </PanelBlockHeader>
         <PanelBlockBody>
           <PanelBlockScroll id='explore-nav'>

--- a/app/assets/scripts/components/common/products-navigation.js
+++ b/app/assets/scripts/components/common/products-navigation.js
@@ -108,11 +108,6 @@ class ProductsNavigation extends React.Component {
         <PanelBlockBody>
           <PanelBlockScroll id='explore-nav'>
             <ul>
-              <li>
-                <PanelNavLink to='/products/global' exact title='Explore global map'>
-                  All
-                </PanelNavLink>
-              </li>
               {products.map((ss) => (
                 <li key={ss.id}>
                   <PanelNavLink

--- a/app/assets/scripts/components/country-pilots/hub/index.js
+++ b/app/assets/scripts/components/country-pilots/hub/index.js
@@ -44,7 +44,7 @@ class CountryPilotHub extends React.Component {
           <InpageHeader>
             <InpageHeaderInner>
               <InpageHeadline>
-                <InpageTitle>Understanding Country Pilot Areas</InpageTitle>
+                <InpageTitle>Understanding Country Pilots</InpageTitle>
               </InpageHeadline>
             </InpageHeaderInner>
           </InpageHeader>

--- a/app/assets/scripts/components/products/hub/index.js
+++ b/app/assets/scripts/components/products/hub/index.js
@@ -44,7 +44,7 @@ class ProductHub extends React.Component {
           <InpageHeader>
             <InpageHeaderInner>
               <InpageHeadline>
-                <InpageTitle>Understanding Products Areas</InpageTitle>
+                <InpageTitle>Understanding Products</InpageTitle>
               </InpageHeadline>
             </InpageHeaderInner>
           </InpageHeader>


### PR DESCRIPTION
This change removes the "All" option from the left sidebar menu when viewing Products. This pseudo-Product will be added to the API so it gets rendered along with the other products.