### PR TITLE
use light-v10 as the mapbox basemap

### DIFF
--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -15,7 +15,7 @@ module.exports = {
       zoom: 2,
       minZoom: 1,
       maxZoom: 20,
-      styleUrl: 'mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
+      styleUrl: 'mapbox://styles/mapbox/light-v10'
     }
   }
 };


### PR DESCRIPTION
Use the MapBox light-v10 basemap instead of the covid19 satellite imagery base map. This allows better viewing of datasets with many transparent areas, especially when they're the colormap is mostly green and the visual is also mostly green.

Example:

![image](https://user-images.githubusercontent.com/124996/138171218-b13f111d-bbb6-4cfb-8dee-5b5ddeb14d1c.png)

Previous:

![image](https://user-images.githubusercontent.com/124996/138171304-53136558-ca4b-4a7b-b98d-8209108d9e2e.png)
