### PR TITLE
enable icesat2_boreal when product selected

### DIFF
--- a/app/assets/scripts/components/home/stories/story-boreal.js
+++ b/app/assets/scripts/components/home/stories/story-boreal.js
@@ -1,6 +1,6 @@
 export default {
-  productId: 'above_boreal',
+  productId: 'icesat2_boreal',
   prose: 'The Advanced Topographic Laser Altimeter System (ATLAS) instrument on-board ICESat-2 will utilize photon counting technology for the altimetry observations. Photon counting technology is relatively new to the vegetation mapping community thus requires development of new algorithm approaches for terrain surface and canopy height retrievals. The algorithm developed specifically for the extraction of terrain and canopy heights from the ATLAS point clouds produces the ATL08 geophysical data product (source: https://www.sciencedirect.com/science/article/abs/pii/S0034425718305066).',
   layers: [''],
-  link: '/products/above_boreal'
+  link: '/products/icesat2_boreal'
 };

--- a/app/assets/scripts/components/products/single/index.js
+++ b/app/assets/scripts/components/products/single/index.js
@@ -299,7 +299,7 @@ class ProductSingle extends React.Component {
       case 'nasa_jpl':
         common.layers.default = 'nasa_jpl';
         break;
-      case 'above_boreal':
+      case 'icesat2_boreal':
         common.layers.default = 'above_biomass';
         break;
       case 'nceo_africa':


### PR DESCRIPTION
above_boreal changed to icesat2_boreal, so the primary layer was no longer selected when the product was chosen.