### PR TITLE
double-deploy to work with proxy prefix or not

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -21,7 +21,7 @@ export class CdkStack extends cdk.Stack {
     new s3Deployment.BucketDeployment(this, "deployStaticWebsiteSubDir", {
       sources: [s3Deployment.Source.asset("../dist")],
       destinationBucket: myBucket,
-      destinationKeyPrefix: "biomass/"
+      destinationKeyPrefix: "maap-biomass/"
     });
   }
 }


### PR DESCRIPTION
This deploys the dashboard to the s3 bucket at both the root and `/maap-biomass` prefix, so it **should** work with the earthdata proxy.