### PR TITLE
Fix sync issue with maap-biomass-prefixed-deploy

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -13,15 +13,19 @@ export class CdkStack extends cdk.Stack {
       websiteIndexDocument: "index.html"
     });
 
-    new s3Deployment.BucketDeployment(this, "deployStaticWebsite", {
+    const root = new s3Deployment.BucketDeployment(this, "deployStaticWebsite", {
       sources: [s3Deployment.Source.asset("../dist")],
-      destinationBucket: myBucket
+      destinationBucket: myBucket,
+      retainOnDelete: true
     });
 
-    new s3Deployment.BucketDeployment(this, "deployStaticWebsiteSubDir", {
+    const maap_biomass = new s3Deployment.BucketDeployment(this, "deployStaticWebsiteSubDir", {
       sources: [s3Deployment.Source.asset("../dist")],
       destinationBucket: myBucket,
       destinationKeyPrefix: "maap-biomass/"
     });
+
+    maap_biomass.node.addDependency(root);
+
   }
 }


### PR DESCRIPTION
The symptom was that the /maap-biomass directory ended up with a random subset of the files it should have had. This was because the the "root" deployment was trying to delete the /maap-biomass directory because of the default "retain" policy was telling it to delete any files that weren't part of the current deployment. This then conflicted with the subdir deployment trying to create those files, so only a few of them were kept. 

The solution is to create an explicit dependency between the two deployments to they run serially.